### PR TITLE
Increased minimum python version deps to fixed error mentioned in #14

### DIFF
--- a/src/platechain/chain.py
+++ b/src/platechain/chain.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from typing import Union
 
 from langchain.chat_models import ChatOpenAI
 from langchain.prompts import ChatPromptTemplate, SystemMessagePromptTemplate
@@ -37,9 +38,9 @@ prompt = ChatPromptTemplate.from_messages(
 
 class ParsePlateRequest(BaseModel):
     df: pd.DataFrame
-    num_plates: int | None
-    num_rows: int | None
-    num_cols: int | None
+    num_plates: Union[int, None]
+    num_rows: Union[int, None]
+    num_cols: Union[int, None]
 
     class Config:
         # Needed to allow pandas dataframes as a type
@@ -152,9 +153,9 @@ chain = (
 
 def parse_plates(
     df: pd.DataFrame,
-    num_plates: int | None = None,
-    num_rows: int | None = None,
-    num_cols: int | None = None,
+    num_plates: Union[int, None] = None,
+    num_rows: Union[int, None] = None,
+    num_cols: Union[int, None] = None,
 ) -> list[pd.DataFrame]:
     """
     df must have a numeric index

--- a/src/platechain/prompts.py
+++ b/src/platechain/prompts.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from typing import Union
+
 FULL_PROMPT = """# Context
 - Plate-based data is rectangular and could be situated anywhere within the dataset.
 - The first item in every row is the row index
 {hint}
 
 # Rules
-- Ignore all data which is not part of the plate. 
+- Ignore all data which is not part of the plate.
 - Row identifiers start with a single letter of the alphabet.
 - The header row of the plate has monotonically increasing integers {col_range_str}.
 - The header row should NOT be considered the starting row of the plate.
@@ -56,7 +58,11 @@ AI_REPONSE_DICT = {
 }
 
 
-def create_prompt(num_plates: int | None, num_rows: int | None, num_cols: int | None):
+def create_prompt(
+    num_plates: Union[int, None],
+    num_rows: Union[int, None],
+    num_cols: Union[int, None],
+):
     additional_prompts = []
     if num_plates:
         num_plates_str = f"are {num_plates} plates" if num_plates > 1 else "is 1 plate"


### PR DESCRIPTION
As mentioned in #14 some of the type hinting is not compatible with versions of pytho <=3.10, so I've modified the pyproject.toml to reflect that.